### PR TITLE
include R_ext/Rdynload.h to build on R < 3.4

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -1,6 +1,7 @@
 #define R_NO_REMAP
 #include <R.h>
 #include <Rinternals.h>
+#include <R_ext/Rdynload.h>
 
 #ifndef WIN32
 # include <unistd.h>


### PR DESCRIPTION
As found in <https://stat.ethz.ch/pipermail/r-help/2019-June/463185.html>, `process.c` only includes `Rinternals.h`, which includes `R_ext/Rdynload.h` in newer versions of R, but not in older ones. A quick look at "Writing R extensions" doesn't seem to show that `Rinternals.h` is guaranteed to `#include <R_ext/Rdynload.h>`.

This pull request adds the `#include` required to build the package on older R versions.